### PR TITLE
Fix the +e plugins not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ source xxh.zsh myhost
 Xxh support environment variables: `xxh myhost +e NAME=VAL` or `~/.config/xxh/config.xxhc` (`$XDG_CONFIG_HOME`) config.
 
 * `+e ZSH_THEME=clean` - set theme
-* `+e plugins="(git ubuntu)"` - set plugins list
+* `+e plugins_="(git ubuntu)"` - set plugins list

--- a/pluginrc.zsh
+++ b/pluginrc.zsh
@@ -14,9 +14,10 @@ else
   export ZSH_THEME="agnoster"
 fi
 
-if [[ -v plugins ]]; then
+if [[ -v plugins_ ]]; then
   if [[ $XXH_VERBOSE == '2' ]]; then
-    echo $plugin_name: Found plugins=$plugins
+    echo $plugin_name: Found plugins=$plugins_
+    eval "export plugins=$plugins_"
   fi
 else
   if [[ $XXH_VERBOSE == '2' ]]; then


### PR DESCRIPTION
Replace plugins with plugins_ in env. variable and then eval it as list variable in pluginrc.zsh