### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">  
-<a href="https://github.com/ohmyzsh/ohmyzsh/">Oh My Zsh</a> plugin for <a href="github.com/xxh/xxh-shell-zsh">xxh-shell-zsh</a>.
+<a href="https://github.com/ohmyzsh/ohmyzsh/">Oh My Zsh</a> plugin for <a href="//github.com/xxh/xxh-shell-zsh">xxh-shell-zsh</a>.
 </p>
 
 <p align="center">  


### PR DESCRIPTION
The link to xxh-shell-zsh used a relative path instead of an absolute path, redirecting to `https://github.com/xxh/xxh-plugin-zsh-ohmyzsh/blob/master/github.com/xxh/xxh-shell-zsh` (404 for obvious reasons) instead of `https://github.com/xxh/xxh-shell-zsh`